### PR TITLE
Tweaks for separation of mysql schema from mysql replication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
     	<groupId>net.sf.jopt-simple</groupId>
     	<artifactId>jopt-simple</artifactId>
-    	<version>4.9-beta-1</version>
+    	<version>4.9</version>
     </dependency>
     <dependency>
     	<groupId>net.snaq</groupId>

--- a/src/main/java/com/zendesk/maxwell/Maxwell.java
+++ b/src/main/java/com/zendesk/maxwell/Maxwell.java
@@ -40,6 +40,8 @@ public class Maxwell {
 
 		this.context = new MaxwellContext(this.config);
 
+		this.context.probeConnections();
+
 		try ( Connection connection = this.context.getReplicationConnectionPool().getConnection(); Connection schemaConnection = context.getMaxwellConnectionPool().getConnection() ) {
 			MaxwellMysqlStatus.ensureReplicationMysqlState(connection);
 			MaxwellMysqlStatus.ensureMaxwellMysqlState(schemaConnection);
@@ -61,7 +63,7 @@ public class Maxwell {
 				initFirstRun(connection, schemaConnection);
 			}
 		} catch ( SQLException e ) {
-			LOGGER.error("Failed to connect to mysql server @ " + this.config.replicationMysql.getConnectionURI());
+			LOGGER.error("SQLException: " + e.getLocalizedMessage());
 			LOGGER.error(e.getLocalizedMessage());
 			return;
 		}

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -54,12 +54,12 @@ public class MaxwellConfig {
 		parser.accepts( "replication_host", "mysql host to treat as master (if using separate schema and replication servers)" ).withRequiredArg();
 		parser.accepts( "replication_user", "mysql username with replication privileges (if using separate schema and replication servers)" ).withRequiredArg();
 		parser.accepts( "output_file", "output file for 'file' producer" ).withRequiredArg();
-		parser.accepts( "replication_password", "mysql password for replication_user (if using separate schema and replication servers)" ).withRequiredArg();
+		parser.accepts( "replication_password", "mysql password for replication_user (if using separate schema and replication servers)" ).withOptionalArg();
 		parser.accepts( "replication_port", "port for mysql replication_host (if using separate schema and replication servers)" ).withRequiredArg();
 
 		parser.accepts( "host", "mysql host with write access to maxwell database" ).withRequiredArg();
 		parser.accepts( "user", "mysql username with write access to maxwell database on host" ).withRequiredArg();
-		parser.accepts( "password", "mysql password for user on host" ).withRequiredArg();
+		parser.accepts( "password", "mysql password for user on host" ).withOptionalArg();
 		parser.accepts( "port", "mysql port for host" ).withRequiredArg();
 
 		parser.accepts( "producer", "producer type: stdout|file|kafka" ).withRequiredArg();
@@ -243,15 +243,11 @@ public class MaxwellConfig {
 			this.maxwellMysql.host = "localhost";
 		}
 
-		if ( this.maxwellMysql.password == null )
-			usage("maxwell mysql password not given");
-
 		if ( this.replicationMysql.port == null )
 			this.replicationMysql.port = 3306;
 
 		if ( this.replicationMysql.host == null
-				|| this.replicationMysql.user == null
-				|| this.replicationMysql.password == null) {
+				|| this.replicationMysql.user == null ) {
 
 			if (this.replicationMysql.host != null
 					|| this.replicationMysql.user != null

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -12,5 +12,8 @@
    <Logger name="snaq.db.ConnectionPool.MaxwellConnectionPool" level="off" additivity="false">
       <AppenderRef ref="Console"/>
     </Logger>
+   <Logger name="snaq.db.ConnectionPool.ReplicationConnectionPool" level="off" additivity="false">
+      <AppenderRef ref="Console"/>
+    </Logger>
   </Loggers>
 </Configuration>

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -12,5 +12,8 @@
    <Logger name="snaq.db.ConnectionPool.MaxwellConnectionPool" level="off" additivity="false">
       <AppenderRef ref="Console"/>
     </Logger>
+    <Logger name="snaq.db.ConnectionPool.ReplicationConnectionPool" level="off" additivity="false">
+      <AppenderRef ref="Console"/>
+    </Logger>
   </Loggers>
 </Configuration>


### PR DESCRIPTION
@kristiankaufmann, here's a couple of tweaks to your code I came up with while trying it out:
- probe both connections early, so that if we can't connect to one of them we can message properly which connection failed -- I was in a situation where one connection was misconfigured but maxwell told me it was the other one.
- make allowances for empty passwords; it is a valid configuration, annoying though it may be.  It's somewhat tangential to this PR but whatever. 
- silence the ridiculously chatty ConnectionPool logger, again.

cc @zendesk/rules
